### PR TITLE
Upload JSON file as a MapMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ usage: java -jar a-<version>-with-dependencies.jar [-A] [-a] [-b <arg>]
                                supported by platform. I.e. Azure Service
                                Bus. When set to false, the Move option is
                                NOT atomic.
- -t,--type <arg>               Message type to put, [bytes, text] -
+ -t,--type <arg>               Message type to put, [bytes, text, map] -
                                defaults to text
  -U,--user <arg>               Username to connect to broker
  -w,--wait <arg>               Time to wait on get operation. Default 50.
@@ -105,6 +105,10 @@ Example 7. Put file foo.bar as text message on queue q, with encoding EBCDIC CP0
 Example 8. Read all XML files in a folder input an put them on queue q. Files are deleted afterwards.
 
     $a -R "input/*.xml" q
+
+Example 9. Put file foo.json as map message on queue q
+
+    $a -p "@foo.json" -t map q
 
 #Use AMQP 1.0
 A defaults to ActiveMQ default protocol, OpenWire. You can also use AMQP 1.0.

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
 		<artifactId>minimal-json</artifactId>
 		<version>0.9.4</version>
 	</dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.8.7</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -35,6 +35,8 @@ import javax.jms.TextMessage;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.command.ActiveMQMessage;
@@ -122,6 +124,8 @@ public class A {
 	public static final String DEFAULT_COUNT_ALL = "0";
 	public static final String DEFAULT_WAIT = "50";
 	public static final String TYPE_TEXT = "text";
+	public static final String TYPE_BYTE = "byte";
+	public static final String TYPE_MAP = "map";
 	public static final String DEFAULT_TYPE = TYPE_TEXT;
 	public static final String DEFAULT_DATE_FORMAT = "yyyy MM dd HH:mm:ss";
 
@@ -564,10 +568,20 @@ public class A {
 					.substring(1)));
 			if (type.equals(TYPE_TEXT)) {
 				outMsg = sess.createTextMessage(new String(bytes, encoding));
-			} else {
+			} else if(type.equals(TYPE_BYTE)) {
 				BytesMessage bytesMsg = sess.createBytesMessage();
 				bytesMsg.writeBytes(bytes);
 				outMsg = bytesMsg;
+			} else if(type.equals(TYPE_MAP)) {
+				MapMessage mapMsg = sess.createMapMessage();
+				ObjectMapper mapper = new ObjectMapper();
+				Map<String, Object> msg = mapper.readValue(bytes, new TypeReference<Map<String, Object>>() { });
+				for (String key : msg.keySet()) {
+					mapMsg.setObject(key, msg.get(key));
+				}
+				outMsg = mapMsg;
+			} else {
+				throw new IllegalArgumentException(CMD_TYPE + ": " + type);
 			}
 		} else {
 			outMsg = sess.createTextMessage(data);

--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -17,6 +17,7 @@ import java.util.Enumeration;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.Map;
 
 import javax.jms.BytesMessage;
 import javax.jms.Connection;

--- a/src/test/java/co/nordlander/a/BaseTest.java
+++ b/src/test/java/co/nordlander/a/BaseTest.java
@@ -30,6 +30,7 @@ import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+import javax.jms.MapMessage;
 
 import org.apache.activemq.broker.BrokerService;
 import org.apache.commons.io.FileUtils;
@@ -356,7 +357,23 @@ public abstract class BaseTest {
         assertEquals(1,msgs.size());
         assertEquals("theOne",msgs.get(0).getText());
     }
-    
+
+    @Test
+    public void testSendMapMessage() throws Exception {
+        File folder = tempFolder.newFolder();
+        final String msgInJson = "{\"TYPE\":\"test\", \"ID\":1}";
+        final File file = new File(folder, "file1.json");
+        FileUtils.writeStringToFile(file, msgInJson, StandardCharsets.UTF_8);
+
+        final String cmdLine = getConnectCommand() + "-" + CMD_PUT + "@" + file.getAbsolutePath() + " -" + CMD_TYPE + " " + TYPE_MAP + " TEST.QUEUE";
+        a.run(cmdLine.split(" "));
+
+        MessageConsumer mc = session.createConsumer(testQueue);
+        MapMessage msg1 = (MapMessage)mc.receive(TEST_TIMEOUT);
+        assertEquals(msg1.getString("TYPE"), "test");
+        assertEquals(msg1.getInt("ID"), 1);
+    }
+
     @Test
     public void testReadFolder() throws Exception {
     	File folder = tempFolder.newFolder();

--- a/src/test/java/co/nordlander/a/BaseTest.java
+++ b/src/test/java/co/nordlander/a/BaseTest.java
@@ -8,6 +8,8 @@ import static co.nordlander.a.A.CMD_PRIORITY;
 import static co.nordlander.a.A.CMD_PUT;
 import static co.nordlander.a.A.CMD_READ_FOLDER;
 import static co.nordlander.a.A.CMD_WAIT;
+import static co.nordlander.a.A.CMD_TYPE;
+import static co.nordlander.a.A.TYPE_MAP;
 import static org.junit.Assert.*;
 
 import java.io.File;


### PR DESCRIPTION
Added new values for `-t` option: `byte`, `text`, `map`.

JSON file should contain keys and values which will be added to `MapMessage`. 