### PR TITLE
Fix default count condition.

### DIFF
--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -414,7 +414,7 @@ public class A {
 		long wait = Long.parseLong(cmdLine.getOptionValue(CMD_WAIT,
 				DEFAULT_WAIT));
 		int i = 0;
-		while (i < count || i == 0) {
+		while (i < count || count == 0) {
 			Message msg = mq.receive(wait);
 			if (msg == null) {
 				output("No message received");
@@ -581,7 +581,7 @@ public class A {
 		
 		List<Message> msgs = new ArrayList<Message>();
 		int i = 0;
-		while (i < count || i == 0) {
+		while (i < count || count == 0) {
 			Message msg = mq.receive(wait);
 			if (msg == null) {
 				break;


### PR DESCRIPTION
It is said that count is 0 (infinity) by default when in reality it always only handle first message from queue.