### PR TITLE
fix queue name when prefix queue: or queue:// is used

### DIFF
--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -785,7 +785,7 @@ public class A {
 		// support queue:// as well.
 		final String correctedName = name.replace("queue://", "queue:").replace("topic://", "topic:");
 		if (correctedName.toLowerCase().startsWith("queue:")) {
-			return sess.createQueue(correctedName);
+			return sess.createQueue(correctedName.substring("queue:".length()));
 		} else if (correctedName.toLowerCase().startsWith("topic:")) {
 			return sess.createTopic(correctedName.substring("topic:".length()));
 		} else {


### PR DESCRIPTION
When prefixes "queue:" or "topic:" are used, this indicates to A that the destination is a queue or topic.
For a topic, that prefix is removed from the name.
For a queue, that does not happen yet and the name including "queue:" becomes the queue name. This PR fixes that.

Since "queue:" is also the default, most people would use the destination without the prefix anyway, thereby avoiding the problem.