### PR TITLE
add option to make topic subscriptions durable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Used to send, browse and put messages on queues.
 
 ```bash
 usage: java -jar a-<version>-with-dependencies.jar [-A] [-a] [-b <arg>]
-       [-B <property=value>] [-c <arg>] [-C <arg>] [-e <arg>] [-E <arg>]
-       [-f <arg>] [-F <arg>] [-g] [-H <property=value>] [-i <arg>] [-I
-       <property=value>] [-j] [-J <arg>] [-k <arg>] [-l] [-L
+       [-B <property=value>] [-c <arg>] [-C <arg>] [-d <arg>] [-e <arg>]
+       [-E <arg>] [-f <arg>] [-F <arg>] [-g] [-H <property=value>] [-i
+       <arg>] [-I <property=value>] [-j] [-J <arg>] [-k <arg>] [-l] [-L
        <property=value>] [-M <arg>] [-n] [-o <arg>] [-O] [-p <arg>] [-P
        <arg>] [-r <arg>] [-R <arg>] [-s <arg>] [-S <arg>] [-t <arg>] [-T]
        [-U <arg>] [-v] [-w <arg>] [-W <arg>] [-x <arg>] [-X <arg>] [-y
@@ -30,6 +30,8 @@ usage: java -jar a-<version>-with-dependencies.jar [-A] [-a] [-b <arg>]
  -C,--copy-queue <arg>         Copy all messages from this to target.
                                Limited by maxBrowsePageSize in broker
                                settings (default 400).
+ -d,--durable <arg>            the subscription is durable, specify
+                               subscription-name
  -e,--encoding <arg>           Encoding of input file data. Default UTF-8
  -E,--correlation-id <arg>     Set CorrelationID
  -f,--find <arg>               Search for messages in queue with this

--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -95,6 +95,7 @@ public class A {
 	public static final String CMD_BROKER = "b";
 	public static final String CMD_COPY_QUEUE = "C";
 	public static final String CMD_COUNT = "c";
+	public static final String CMD_DURABLE = "d";
 	public static final String CMD_CORRELATION_ID = "E";
 	public static final String CMD_ENCODING = "e";
 	public static final String CMD_JNDI_CF = "F";
@@ -129,7 +130,6 @@ public class A {
 	public static final String CMD_JMS_TYPE = "y";
 	public static final String CMD_TTL = "z";
 	public static final String CMD_CLIENTID = "k";
-	public static final String CMD_DURABLE = "Z";
 	
 	// Various constants
 	public static final long SLEEP_TIME_BETWEEN_FILE_CHECK = 1000L;


### PR DESCRIPTION
For topic based scenarios, it is useful to use durable subscriptions. i.e. the consumer stays subscribed after it terminates and thus closes the connection. that way, no messages are lost when a client is temporarily disconnected.
Added option `-d`, which causes the subscription-id to be set and the subscription to become durable.
Only useable on topics of course and only for the `--get` scenario.

Tested with Artemis 2.16.0

The documentation in README.md was updated by replacing the "usage" output with the output from this version. the new option is in there, but some other options were shifted up/down.