### PR TITLE
prevent string replacement in the middle of the destination and/or duplicate replacement

### DIFF
--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -787,7 +787,7 @@ public class A {
 	protected Destination createDestination(final String name)
 			throws JMSException {
 		// support queue:// as well.
-		final String correctedName = name.replace("queue://", "queue:").replace("topic://", "topic:");
+		final String correctedName = name.replaceFirst("^queue://", "queue:").replaceFirst("^topic://", "topic:");
 		if (correctedName.toLowerCase().startsWith("queue:")) {
 			return sess.createQueue(correctedName.substring("queue:".length()));
 		} else if (correctedName.toLowerCase().startsWith("topic:")) {


### PR DESCRIPTION
"A" interprets destination names that start with queue:(//) or topic:(//) to use the proper API.
But some brokers, like ActiveMQ, also interpret prefixes with the same text.
This makes it sometimes necessary to use {{queue://queue://actualquename}}
But the current prefix detection does not only find the prefix, it finds all occurrences.

This PR changes the test so that only one string at the beginning of the destination name is considered.

e.g. starting with {{queue://queue://actualquename}}:
* "A" will remove the first {{queue://}} and sends {{queue://actualquename}} to the server
* the server will remove the second {{queue://}} and properly uses {{actualquename}}