### PR TITLE
close all sessions

### DIFF
--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -199,6 +199,10 @@ public class A {
 					sess.close();
 				}
 
+				if (tsess != null) {
+					tsess.close();
+				}
+
 				if (conn != null) {
 					conn.close();
 				}


### PR DESCRIPTION
To support (no)transactions, an additional session was set up. However, that one was never closed before closing the connection.

Found while investigating "AMQ222061: Client connection failed, clearing up resources for session" in ActiveMQ Artemis. this was not the solution for that problem though...