### PR TITLE
Add the wait flag to the move command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ usage: java -jar a-<version>-with-dependencies.jar [-A] [-a] [-b <arg>]
                                NOT atomic.
  -U,--user <arg>               Username to connect to broker
  -v,--version                  Show version of A
- -w,--wait <arg>               Time to wait on get operation. Default 50.
-                               0 equals infinity
+ -w,--wait <arg>               Time to wait for a message on get or move 
+                               operations in milliseconds. Default 100. 
+                               0 equals infinity.
  -W,--batch-file <arg>         Line separated batch file. Used with -p to
                                produce one message per line in file. Used
                                together with Script where each batch line

--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -135,7 +135,7 @@ public class A {
 	public static final long SLEEP_TIME_BETWEEN_FILE_CHECK = 1000L;
 	public static final String DEFAULT_COUNT_GET = "1";
 	public static final String DEFAULT_COUNT_ALL = "0";
-	public static final String DEFAULT_WAIT = "50";
+	public static final String DEFAULT_WAIT = "100";
 	public static final String TYPE_TEXT = "text";
 	public static final String TYPE_BYTES = "bytes";
 	public static final String TYPE_MAP = "map";
@@ -1177,7 +1177,7 @@ public class A {
 		opts.addOption(CMD_SELECTOR, "selector", true,
 				"Browse or get with selector. I.e JMSType = 'car' AND color = 'blue'");
 		opts.addOption(CMD_WAIT, "wait", true,
-				"Time to wait on get or move operation. Default 50. 0 equals infinity");
+				"Time to wait on get or move operation. Default 100. 0 equals infinity");
 		opts.addOption(CMD_USER, "user", true, "Username to connect to broker");
 		opts.addOption(CMD_PASS, "pass", true, "Password to connect to broker");
 		opts.addOption(CMD_PRIORITY, "priority", true, "sets JMSPriority");

--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -1177,7 +1177,7 @@ public class A {
 		opts.addOption(CMD_SELECTOR, "selector", true,
 				"Browse or get with selector. I.e JMSType = 'car' AND color = 'blue'");
 		opts.addOption(CMD_WAIT, "wait", true,
-				"Time to wait on get or move operation. Default 100. 0 equals infinity");
+				"Time to wait for a message on get or move operations in milliseconds. Default 100. 0 equals infinity");
 		opts.addOption(CMD_USER, "user", true, "Username to connect to broker");
 		opts.addOption(CMD_PASS, "pass", true, "Password to connect to broker");
 		opts.addOption(CMD_PRIORITY, "priority", true, "sets JMSPriority");

--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -258,10 +258,13 @@ public class A {
 		}
 		int count = Integer.parseInt(cmdLine.getOptionValue(CMD_COUNT,
 				DEFAULT_COUNT_ALL));
+		long wait = Long.parseLong(cmdLine.getOptionValue(CMD_WAIT,
+				DEFAULT_WAIT));
 		int j = 0;
 		while (j < count || count == 0) {
-			Message msg = mq.receive(100L);
+			Message msg = mq.receive(wait);
 			if (msg == null) {
+				output("No message received, due to the timeout expiring or the consumer is closed");
 				break;
 			} else {
 				sendWithOptionalTransformer(cmdLine, msg, mp);
@@ -1174,7 +1177,7 @@ public class A {
 		opts.addOption(CMD_SELECTOR, "selector", true,
 				"Browse or get with selector. I.e JMSType = 'car' AND color = 'blue'");
 		opts.addOption(CMD_WAIT, "wait", true,
-				"Time to wait on get operation. Default 50. 0 equals infinity");
+				"Time to wait on get or move operation. Default 50. 0 equals infinity");
 		opts.addOption(CMD_USER, "user", true, "Username to connect to broker");
 		opts.addOption(CMD_PASS, "pass", true, "Password to connect to broker");
 		opts.addOption(CMD_PRIORITY, "priority", true, "sets JMSPriority");


### PR DESCRIPTION
We ran into an issue when attempting to move a queue that contained large messages that went beyond the hardcoded 100ms message timeout for consuming messages. This caused the move to not complete at all since the large messages were the first to be consumed from the queue, and it didn't have any output indicating that an internal timeout was hit.

This adds the wait flag already used for other operations to the move command so that the timeout can be extended/disabled when moving large queues. I've also nudged up the default from 50ms to 100ms for consistency and added some output if the message is null from the timeout/consumer being closed. 