### PR TITLE
Use Java 17 for building and running the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- Build time image --
-FROM maven:3.8.6-openjdk-11-slim AS build
+FROM maven:3-eclipse-temurin-17 AS build
 
 LABEL maintainer="petter@fourmation.se"
 
@@ -24,7 +24,7 @@ RUN sed --in-place \
 RUN cd /usr/local/a && mvn package -DskipTests
 
 # -- Runtime Image --
-FROM openjdk:8-alpine
+FROM eclipse-temurin:17
 
 COPY --from=build /usr/local/a/target/*-jar-with-dependencies.jar /a/a.jar
 


### PR DESCRIPTION
It looks like #185 updated the Dockerfile to use Java 11 at build time, but since the runtime base image still uses Java 8, it would fail at startup:
```
$ docker build -t a:latest .
$ docker run --rm -t -i a:latest a -b …

Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.UnsupportedClassVersionError: co/nordlander/a/A has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions u
p to 52.0
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
        at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
        at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
        at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:495)
```

This PR updates to use Java 17 for building and running, and switches away from the [deprecated](https://hub.docker.com/_/openjdk) openjdk image.

With these changes, I was able to build the container image and run it as expected.